### PR TITLE
Table部分のendpointとschemaのリンクを別塊で表示する

### DIFF
--- a/lib/prmd/templates/table_of_contents.erb
+++ b/lib/prmd/templates/table_of_contents.erb
@@ -1,11 +1,19 @@
 <%- Prmd::Template.render('schemata/helper.erb', options[:template]) -%>
 ## The table of contents
+<% keys = schema['properties'].keys.sort %>
 
-<% schema['properties'].keys.sort.map do |key| %>
+### Endpoints
+<% keys.map do |key| %>
+  <%  property = schema['properties'][key] %>
+  <% _, schemata = schema.dereference(property) %>
+  <% schemata.fetch('links', []).each do |l| %>
+- <a href="#<%= schemata['title'].gsub(/\s/, '-').downcase %>-<%= l['title'].gsub(/\s/, '-').downcase %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
+  <% end %>
+<% end %>
+
+### Schema
+<% keys.map do |key| %>
   <% resource, property = key, schema['properties'][key] %>
   <% _, schemata = schema.dereference(property) %>
 - <a href="#resource-<%= resource %>"><%= schemata['title'].split(' - ', 2).last %></a>
-  <% schemata.fetch('links', []).each do |l| %>
-  - <a href="#<%= schemata['title'].gsub(/\s/, '-').downcase %>-<%= l['title'].gsub(/\s/, '-').downcase %>"><%= l['method'] %> <%= build_link_path(schema, l) %></a>
-  <% end %>
 <% end %>

--- a/lib/prmd/version.rb
+++ b/lib/prmd/version.rb
@@ -2,7 +2,7 @@
 module Prmd
   # Well, duh, its a Version module, what did you expect?
   module Version
-    MAJOR, MINOR, TEENY, PATCH = 0, 13, 0, nil
+    MAJOR, MINOR, TEENY, PATCH = 0, 13, 0, 'k1'
     # version string
     # @return [String]
     STRING = [MAJOR, MINOR, TEENY, PATCH].compact.join('.').freeze


### PR DESCRIPTION
## やったこと

API DocのTable of contents部について、endpointとschemaのリンクが別々のほうが見やすいとの事だったので、対応しました。
